### PR TITLE
Stop adding the click function to UIButton in its initializer

### DIFF
--- a/BaseballLineupIOS/View/ViewController/OrderViewController.swift
+++ b/BaseballLineupIOS/View/ViewController/OrderViewController.swift
@@ -85,33 +85,23 @@ class OrderViewController: BaseADViewController {
     }()
     
     private lazy var cancelButton: UIButton = {
-        let button = createOperationButton(title: "キャンセル")
-        button.addTarget(self, action: #selector(onClickCancel), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "キャンセル")
     }()
     
     private lazy var registerButton: UIButton = {
-        let button = createOperationButton(title: "登録")
-        button.addTarget(self, action: #selector(onClickRegister), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "登録")
     }()
     
     private lazy var exchangeButton: UIButton = {
-        let button = createOperationButton(title: "入替")
-        button.addTarget(self, action: #selector(onClickExchange), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "入替")
     }()
     
     private lazy var addOrderButton: UIButton = {
-        let button = createOperationButton(title: "追加")
-        button.addTarget(self, action: #selector(onClickAdd), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "追加")
     }()
     
     private lazy var deleteOrderButton: UIButton = {
-        let button = createOperationButton(title: "削除")
-        button.addTarget(self, action: #selector(onClickDelete), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "削除")
     }()
     
     private func createOperationButton(title: String) -> UIButton {
@@ -258,6 +248,11 @@ class OrderViewController: BaseADViewController {
         view.addSubview(titleLabel)
         view.addSubview(orderTable)
         view.addSubview(bannerAD)
+        cancelButton.addTarget(self, action: #selector(onClickCancel), for: .touchUpInside)
+        registerButton.addTarget(self, action: #selector(onClickRegister), for: .touchUpInside)
+        exchangeButton.addTarget(self, action: #selector(onClickExchange), for: .touchUpInside)
+        addOrderButton.addTarget(self, action: #selector(onClickAdd), for: .touchUpInside)
+        deleteOrderButton.addTarget(self, action: #selector(onClickDelete), for: .touchUpInside)
         
         NSLayoutConstraint.activate([
             registeringStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0),

--- a/BaseballLineupIOS/View/ViewController/SettingViewController.swift
+++ b/BaseballLineupIOS/View/ViewController/SettingViewController.swift
@@ -23,7 +23,6 @@ class SettingViewController: UIViewController {
         button.setTitle("閉じる" , for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 12)
         button.setTitleColor(.black, for: .normal)
-        button.addTarget(self, action: #selector(onClickClose), for: .touchUpInside)
         return button
     }()
     
@@ -47,6 +46,7 @@ class SettingViewController: UIViewController {
         view.addSubview(modal)
         view.addSubview(closeButton)
         view.addSubview(policyLink)
+        closeButton.addTarget(self, action: #selector(onClickClose), for: .touchUpInside)
         
         NSLayoutConstraint.activate([
             modal.centerXAnchor.constraint(equalTo: view.centerXAnchor),

--- a/BaseballLineupIOS/View/ViewController/SubMemberViewController.swift
+++ b/BaseballLineupIOS/View/ViewController/SubMemberViewController.swift
@@ -147,21 +147,15 @@ class SubMemberViewController: BaseADViewController {
     }()
     
     private lazy var cancelB: UIButton = {
-        let button = createOperationButton(title: "キャンセル")
-        button.addTarget(self, action: #selector(onClickCancel), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "キャンセル")
     }()
     
     private lazy var registerB: UIButton = {
-        let button = createOperationButton(title: "登録")
-        button.addTarget(self, action: #selector(onClickRegister), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "登録")
     }()
     
     private lazy var exchangeB: UIButton = {
-        let button = createOperationButton(title: "入替")
-        button.addTarget(self, action: #selector(onClickExchange), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "入替")
     }()
     
     private func createOperationButton(title: String) -> UIButton {
@@ -206,21 +200,15 @@ class SubMemberViewController: BaseADViewController {
     }()
     
     private lazy var addB: UIButton = {
-        let button = createOperationButton(title: "控え追加")
-        button.addTarget(self, action: #selector(onClickAdd), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "控え追加")
     }()
     
     private lazy var deleteB: UIButton = {
-        let button = createOperationButton(title: "控え削除")
-        button.addTarget(self, action: #selector(onClickDelete), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "控え削除")
     }()
     
     private lazy var exchangeWithStartingB: UIButton = {
-        let button = createOperationButton(title: "先発入替")
-        button.addTarget(self, action: #selector(onClickExchangeWithStarting), for: .touchUpInside)
-        return button
+        return createOperationButton(title: "先発入替")
     }()
     
     private lazy var bottomOperationButtonsStack: UIStackView = {
@@ -327,6 +315,12 @@ class SubMemberViewController: BaseADViewController {
         view.addSubview(subPlayerTable)
         view.addSubview(bottomOperationButtonsStack)
         view.addSubview(bannerAD)
+        cancelB.addTarget(self, action: #selector(onClickCancel), for: .touchUpInside)
+        registerB.addTarget(self, action: #selector(onClickRegister), for: .touchUpInside)
+        exchangeB.addTarget(self, action: #selector(onClickExchange), for: .touchUpInside)
+        addB.addTarget(self, action: #selector(onClickAdd), for: .touchUpInside)
+        deleteB.addTarget(self, action: #selector(onClickDelete), for: .touchUpInside)
+        exchangeWithStartingB.addTarget(self, action: #selector(onClickExchangeWithStarting), for: .touchUpInside)
         
         NSLayoutConstraint.activate([
             registeringStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0),

--- a/BaseballLineupIOS/View/ViewController/TopViewController.swift
+++ b/BaseballLineupIOS/View/ViewController/TopViewController.swift
@@ -49,7 +49,6 @@ class TopViewController: UIViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(type.buttonTitle , for: .normal)
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 28)
-        button.addTarget(self, action: #selector(onClickOrderButton), for: .touchUpInside)
         button.tag = type.buttonTag
         button.backgroundColor = type.buttonColor
         button.setTitleColor(.white, for: .normal)
@@ -58,15 +57,11 @@ class TopViewController: UIViewController {
     }
     
     private lazy var restoreButton: UIButton = {
-        let button = createStoreButton(title: Constants.RESTORE_PURCHASE, color: .systemIndigo)
-        button.addTarget(self, action: #selector(onClickRestore), for: .touchUpInside)
-        return button
+        return createStoreButton(title: Constants.RESTORE_PURCHASE, color: .systemIndigo)
     }()
     
     private lazy var purchaseButton: UIButton = {
-        let button = createStoreButton(title: Constants.WHAT_IS_ALL_HITTER, color: .systemIndigo)
-        button.addTarget(self, action: #selector(onClickPurchase), for: .touchUpInside)
-        return button
+        return createStoreButton(title: Constants.WHAT_IS_ALL_HITTER, color: .systemIndigo)
     }()
     
     private func createStoreButton(title: String, color: UIColor) -> UIButton {
@@ -149,6 +144,11 @@ class TopViewController: UIViewController {
         view.addSubview(orderButtons)
         view.addSubview(buttonsAboutStore)
         view.addSubview(descriptions)
+        nonDHOrderButton.addTarget(self, action: #selector(onClickOrderButton), for: .touchUpInside)
+        dhOrderButton.addTarget(self, action: #selector(onClickOrderButton), for: .touchUpInside)
+        specialOrderButton.addTarget(self, action: #selector(onClickOrderButton), for: .touchUpInside)
+        restoreButton.addTarget(self, action: #selector(onClickRestore), for: .touchUpInside)
+        purchaseButton.addTarget(self, action: #selector(onClickPurchase), for: .touchUpInside)
         
         let defaultLeadingSpace = 50.0
         let defaultTrailingSpace = -1.0 * defaultLeadingSpace


### PR DESCRIPTION
- Adding func in UIView's initializer might cause unexpected bugs (ex: the click func is not called).
- Especially when the button is in the other parent view(ex: UIStackView or Just UIView), they can be happened.
- So, this adding process should be done after UIButton is initialized.