### PR TITLE
Change Interstitial Ad frequency

### DIFF
--- a/BaseballLineupIOS/SceneDelegate.swift
+++ b/BaseballLineupIOS/SceneDelegate.swift
@@ -53,6 +53,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        if let navigationController: UINavigationController = window?.rootViewController as? UINavigationController,
+            let tabBarController: CustomTabBarController = navigationController.topViewController as? CustomTabBarController {
+            tabBarController.backToTop()
+        }
     }
 
 

--- a/BaseballLineupIOS/View/ViewController/CustomTabBarController.swift
+++ b/BaseballLineupIOS/View/ViewController/CustomTabBarController.swift
@@ -86,6 +86,10 @@ class CustomTabBarController: UITabBarController {
         let settingVC = SettingViewController()
         navigationController?.pushViewController(settingVC, animated: true)
     }
+    
+    func backToTop() {
+        navigationController?.popViewController(animated: true)
+    }
 }
 
 extension CustomTabBarController: CustomTabBarVMDelegate {

--- a/BaseballLineupIOS/View/ViewController/TopViewController.swift
+++ b/BaseballLineupIOS/View/ViewController/TopViewController.swift
@@ -16,7 +16,6 @@ class TopViewController: UIViewController {
     
     var viewModel: TopViewModel?
     private var isDoneTrackingCheck = false
-    private var isShownInterstitial = false
     private var interstitial: GADInterstitialAd?
     private var indicator: UIActivityIndicatorView?
     
@@ -403,12 +402,12 @@ class TopViewController: UIViewController {
     }
     
     private func showInterstitial() {
-        if isShownInterstitial { return }
         if let _interstitial = interstitial {
             _interstitial.present(fromRootViewController: self)
-            isShownInterstitial = true
+            loadInterstitialAd()
         } else {
             print("Ad wasn't ready")
+            loadInterstitialAd()
         }
     }
     


### PR DESCRIPTION
- It seems that showing Interstitial Ad on UITabBarController when switching Tab might violate the Ad policy.
- This is why App goes to Top when background and show Ad each time when clicking Order buttons.
- ref: https://support.google.com/admob/answer/6201362?hl=ja#zippy=%2C%E9%81%95%E5%8F%8D%E3%82%92%E4%BF%AE%E6%AD%A3%E3%81%99%E3%82%8B%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E6%96%B9%E6%B3%95%2C%E8%A8%B1%E5%8F%AF%E3%81%95%E3%82%8C%E3%81%A6%E3%81%84%E3%81%AA%E3%81%84%E4%BE%8B-%E3%83%9A%E3%83%BC%E3%82%B8%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E5%BE%8C%E3%81%AE%E8%A1%A8%E7%A4%BA